### PR TITLE
fix: Renames OneHotLayer to OneHotEncodeLayer

### DIFF
--- a/src/kamae/spark/transformers/one_hot_encode.py
+++ b/src/kamae/spark/transformers/one_hot_encode.py
@@ -41,7 +41,7 @@ from kamae.spark.utils import (
     one_hot_encoding_udf,
     single_input_single_output_scalar_udf_transform,
 )
-from kamae.tensorflow.layers import OneHotLayer
+from kamae.tensorflow.layers import OneHotEncodeLayer
 
 from .base import BaseTransformer
 
@@ -165,7 +165,7 @@ class OneHotEncodeTransformer(
         :returns: Tensorflow keras layer with name equal to the layerName parameter
         that performs the one-hot encoding.
         """
-        return OneHotLayer(
+        return OneHotEncodeLayer(
             name=self.getLayerName(),
             input_dtype=self.getInputTFDtype(),
             output_dtype=self.getOutputTFDtype(),

--- a/src/kamae/spark/transformers/shared_one_hot_encode.py
+++ b/src/kamae/spark/transformers/shared_one_hot_encode.py
@@ -41,7 +41,7 @@ from kamae.spark.utils import (
     one_hot_encoding_udf,
     single_input_single_output_scalar_udf_transform,
 )
-from kamae.tensorflow.layers import OneHotLayer
+from kamae.tensorflow.layers import OneHotEncodeLayer
 
 from .base import BaseTransformer
 
@@ -168,7 +168,7 @@ class SharedOneHotEncodeTransformer(
         parameter and the input column name, that performs the indexing.
         """
         return [
-            OneHotLayer(
+            OneHotEncodeLayer(
                 name=f"{self.getLayerName()}_{input_name}",
                 input_dtype=self.getInputTFDtype(),
                 output_dtype=self.getOutputTFDtype(),

--- a/src/kamae/tensorflow/layers/__init__.py
+++ b/src/kamae/tensorflow/layers/__init__.py
@@ -54,7 +54,7 @@ from .min import MinLayer  # noqa: F401
 from .modulo import ModuloLayer  # noqa: F401
 from .multiply import MultiplyLayer  # noqa: F401
 from .numerical_if_statement import NumericalIfStatementLayer  # noqa: F401
-from .one_hot_encode import OneHotEncodeLayer  # noqa: F401
+from .one_hot_encode import OneHotEncodeLayer, OneHotLayer  # noqa: F401
 from .ordinal_array_encode import OrdinalArrayEncodeLayer  # noqa: F401
 from .round import RoundLayer  # noqa: F401
 from .round_to_decimal import RoundToDecimalLayer  # noqa: F401
@@ -76,7 +76,3 @@ from .sub_string_delim_at_index import SubStringDelimAtIndexLayer  # noqa: F401
 from .subtract import SubtractLayer  # noqa: F401
 from .sum import SumLayer  # noqa: F401
 from .unix_timestamp_to_date_time import UnixTimestampToDateTimeLayer  # noqa: F401
-
-# TODO: Remove this alias in next breaking change,
-#  it is maintained for backwards compatibility
-OneHotLayer = OneHotEncodeLayer

--- a/src/kamae/tensorflow/layers/__init__.py
+++ b/src/kamae/tensorflow/layers/__init__.py
@@ -54,7 +54,7 @@ from .min import MinLayer  # noqa: F401
 from .modulo import ModuloLayer  # noqa: F401
 from .multiply import MultiplyLayer  # noqa: F401
 from .numerical_if_statement import NumericalIfStatementLayer  # noqa: F401
-from .one_hot_encode import OneHotLayer  # noqa: F401
+from .one_hot_encode import OneHotEncodeLayer  # noqa: F401
 from .ordinal_array_encode import OrdinalArrayEncodeLayer  # noqa: F401
 from .round import RoundLayer  # noqa: F401
 from .round_to_decimal import RoundToDecimalLayer  # noqa: F401
@@ -76,3 +76,7 @@ from .sub_string_delim_at_index import SubStringDelimAtIndexLayer  # noqa: F401
 from .subtract import SubtractLayer  # noqa: F401
 from .sum import SumLayer  # noqa: F401
 from .unix_timestamp_to_date_time import UnixTimestampToDateTimeLayer  # noqa: F401
+
+# TODO: Remove this alias in next breaking change,
+#  it is maintained for backwards compatibility
+OneHotLayer = OneHotEncodeLayer

--- a/src/kamae/tensorflow/layers/one_hot_encode.py
+++ b/src/kamae/tensorflow/layers/one_hot_encode.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 import tensorflow as tf
@@ -152,3 +153,16 @@ class OneHotEncodeLayer(BaseLayer):
             }
         )
         return config
+
+
+# TODO: Remove this alias in next breaking change,
+#  it is maintained for backwards compatibility
+class OneHotLayer(OneHotEncodeLayer):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "OneHotLayer is deprecated and will be removed in a future release. "
+            "Use OneHotEncodeLayer instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/kamae/tensorflow/layers/one_hot_encode.py
+++ b/src/kamae/tensorflow/layers/one_hot_encode.py
@@ -24,7 +24,7 @@ from .base import BaseLayer
 
 
 @tf.keras.utils.register_keras_serializable(package=kamae.__name__)
-class OneHotLayer(BaseLayer):
+class OneHotEncodeLayer(BaseLayer):
     """
     Performs a one-hot encoding of a string input tensor.
 

--- a/tests/kamae/tensorflow/layers/test_one_hot_encode.py
+++ b/tests/kamae/tensorflow/layers/test_one_hot_encode.py
@@ -15,7 +15,7 @@
 import pytest
 import tensorflow as tf
 
-from kamae.tensorflow.layers import OneHotLayer
+from kamae.tensorflow.layers import OneHotEncodeLayer
 
 
 class TestOneHotEncode:
@@ -167,7 +167,7 @@ class TestOneHotEncode:
         expected_output,
     ):
         # when
-        layer = OneHotLayer(
+        layer = OneHotEncodeLayer(
             name=input_name,
             vocabulary=vocabulary,
             num_oov_indices=num_oov_indices,

--- a/tests/kamae/tensorflow/test_layer_serialisation.py
+++ b/tests/kamae/tensorflow/test_layer_serialisation.py
@@ -66,7 +66,7 @@ from kamae.tensorflow.layers import (
     ModuloLayer,
     MultiplyLayer,
     NumericalIfStatementLayer,
-    OneHotLayer,
+    OneHotEncodeLayer,
     OrdinalArrayEncodeLayer,
     RoundLayer,
     RoundToDecimalLayer,
@@ -238,7 +238,7 @@ from kamae.tensorflow.layers import (
             False,
         ),
         (
-            OneHotLayer,
+            OneHotEncodeLayer,
             [tf.constant("a", shape=(100, 10, 1))],
             {"num_oov_indices": 1, "vocabulary": ["a", "b"], "drop_unseen": True},
             False,


### PR DESCRIPTION
Keeps an alias with the name OneHotLayer and so is not a breaking change.

Fixes #8 