### PR TITLE
chore: Remove workflow dispatch from release and publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,6 @@ name: Build dists and publish to PyPI and TestPyPI
 on:
   release:
     types: [ published ]
-  workflow_dispatch:
 
 env:
   UV_VERSION: 0.5.21

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ name: Semantic release with GitHub release
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
-
 
 env:
   UV_VERSION: 0.5.21


### PR DESCRIPTION
This should not be needed anymore since it is all automated.