### PR TITLE
fix: Listwise statistic transforms don't support integers

### DIFF
--- a/src/kamae/spark/transformers/list_max.py
+++ b/src/kamae/spark/transformers/list_max.py
@@ -116,10 +116,6 @@ class ListMaxTransformer(
         return [
             FloatType(),
             DoubleType(),
-            ByteType(),
-            ShortType(),
-            IntegerType(),
-            LongType(),
         ]
 
     def _transform(self, dataset: DataFrame) -> DataFrame:

--- a/src/kamae/spark/transformers/list_min.py
+++ b/src/kamae/spark/transformers/list_min.py
@@ -116,10 +116,6 @@ class ListMinTransformer(
         return [
             FloatType(),
             DoubleType(),
-            ByteType(),
-            ShortType(),
-            IntegerType(),
-            LongType(),
         ]
 
     def _transform(self, dataset: DataFrame) -> DataFrame:

--- a/src/kamae/tensorflow/layers/list_max.py
+++ b/src/kamae/tensorflow/layers/list_max.py
@@ -92,14 +92,6 @@ class ListMaxLayer(BaseLayer):
             tf.float16,
             tf.float32,
             tf.float64,
-            tf.uint8,
-            tf.int8,
-            tf.uint16,
-            tf.int16,
-            tf.int32,
-            tf.int64,
-            tf.complex64,
-            tf.complex128,
         ]
 
     @allow_single_or_multiple_tensor_input

--- a/src/kamae/tensorflow/layers/list_mean.py
+++ b/src/kamae/tensorflow/layers/list_mean.py
@@ -92,14 +92,6 @@ class ListMeanLayer(BaseLayer):
             tf.float16,
             tf.float32,
             tf.float64,
-            tf.uint8,
-            tf.int8,
-            tf.uint16,
-            tf.int16,
-            tf.int32,
-            tf.int64,
-            tf.complex64,
-            tf.complex128,
         ]
 
     @allow_single_or_multiple_tensor_input

--- a/src/kamae/tensorflow/layers/list_median.py
+++ b/src/kamae/tensorflow/layers/list_median.py
@@ -39,6 +39,8 @@ class ListMedianLayer(BaseLayer):
 
     Example: calculate the median price in the same query, based only on the top N
     items sorted by descending production.
+
+    WARNING: ListMedianLayer requires at least rank 3 tensor input.
     """
 
     def __init__(
@@ -92,14 +94,6 @@ class ListMedianLayer(BaseLayer):
             tf.float16,
             tf.float32,
             tf.float64,
-            tf.uint8,
-            tf.int8,
-            tf.uint16,
-            tf.int16,
-            tf.int32,
-            tf.int64,
-            tf.complex64,
-            tf.complex128,
         ]
 
     def sort_with_nans_last(self, tensor: Tensor):

--- a/src/kamae/tensorflow/layers/list_min.py
+++ b/src/kamae/tensorflow/layers/list_min.py
@@ -92,14 +92,6 @@ class ListMinLayer(BaseLayer):
             tf.float16,
             tf.float32,
             tf.float64,
-            tf.uint8,
-            tf.int8,
-            tf.uint16,
-            tf.int16,
-            tf.int32,
-            tf.int64,
-            tf.complex64,
-            tf.complex128,
         ]
 
     @allow_single_or_multiple_tensor_input

--- a/src/kamae/tensorflow/layers/list_std_dev.py
+++ b/src/kamae/tensorflow/layers/list_std_dev.py
@@ -92,14 +92,6 @@ class ListStdDevLayer(BaseLayer):
             tf.float16,
             tf.float32,
             tf.float64,
-            tf.uint8,
-            tf.int8,
-            tf.uint16,
-            tf.int16,
-            tf.int32,
-            tf.int64,
-            tf.complex64,
-            tf.complex128,
         ]
 
     @allow_single_or_multiple_tensor_input


### PR DESCRIPTION
If you try and use integers with these layers they error due to the `float(nan)` and `is_finite` [checks](https://github.com/ExpediaGroup/kamae/blob/238e0adee18af9de498077a1bd3b269debd36807/src/kamae/tensorflow/layers/list_mean.py#L140). Therefore we remove support for int here so we get a better error message.

We also add a warning to ListMedian since it fails without a rank 3 tensor. 