### PR TITLE
docs: Use proper Sphinx docs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -55,5 +55,6 @@ plugins:
           options:
             separate_signature: true
             merge_init_into_class: true
+            docstring_style: sphinx
             docstring_options:
               ignore_init_summary: true

--- a/src/kamae/spark/estimators/one_hot_encode.py
+++ b/src/kamae/spark/estimators/one_hot_encode.py
@@ -74,7 +74,7 @@ class OneHotEncodeEstimator(
         transforming.
         :param outputDtype: Output data type to cast the output column(s) to after
         transforming.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'. Defaults to 'frequencyDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/estimators/shared_one_hot_encode.py
+++ b/src/kamae/spark/estimators/shared_one_hot_encode.py
@@ -75,7 +75,7 @@ class SharedOneHotEncodeEstimator(
         transforming.
         :param outputDtype: Output data type to cast the output column(s) to after
         transforming.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'. Defaults to 'frequencyDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/estimators/shared_string_index.py
+++ b/src/kamae/spark/estimators/shared_string_index.py
@@ -68,7 +68,7 @@ class SharedStringIndexEstimator(
         transforming.
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/estimators/string_index.py
+++ b/src/kamae/spark/estimators/string_index.py
@@ -67,7 +67,7 @@ class StringIndexEstimator(
         transforming.
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/transformers/one_hot_encode.py
+++ b/src/kamae/spark/transformers/one_hot_encode.py
@@ -89,7 +89,7 @@ class OneHotEncodeTransformer(
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
         :param labelsArray: List of string labels to use for one-hot encoding.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'. Defaults to 'frequencyDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/transformers/shared_one_hot_encode.py
+++ b/src/kamae/spark/transformers/shared_one_hot_encode.py
@@ -85,7 +85,7 @@ class SharedOneHotEncodeTransformer(
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
         :param labelsArray: List of string labels to use for one-hot encoding.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'. Defaults to 'frequencyDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/transformers/shared_string_index.py
+++ b/src/kamae/spark/transformers/shared_string_index.py
@@ -74,7 +74,7 @@ class SharedStringIndexTransformer(
         transforming. Must be the same length as inputCols.
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/spark/transformers/string_index.py
+++ b/src/kamae/spark/transformers/string_index.py
@@ -74,7 +74,7 @@ class StringIndexTransformer(
         transforming.
         :param layerName: Name of the layer. Used as the name of the tensorflow layer
         in the keras model. If not set, we use the uid of the Spark transformer.
-        :param: stringOrderType: How to order the string indices.
+        :param stringOrderType: How to order the string indices.
         Options are 'frequencyAsc', 'frequencyDesc', 'alphabeticalAsc',
         'alphabeticalDesc'.
         :param maskToken: Token to use for masking.

--- a/src/kamae/tensorflow/layers/conditional_standard_scale.py
+++ b/src/kamae/tensorflow/layers/conditional_standard_scale.py
@@ -74,8 +74,6 @@ class ConditionalStandardScaleLayer(NormalizeLayer):
         :param output_dtype: The dtype to cast the output to. Defaults to `None`.
         :param epsilon: Small value to add to conditional check of zeros. Valid only
         when skipZeros is True. Defaults to 1e-4.
-        :param input_dtype: The dtype to cast the input to. Defaults to `None`.
-        :param output_dtype: The dtype to cast the output to. Defaults to `None`.
         """
         super().__init__(
             name=name,

--- a/src/kamae/tensorflow/layers/list_median.py
+++ b/src/kamae/tensorflow/layers/list_median.py
@@ -107,7 +107,6 @@ class ListMedianLayer(BaseLayer):
         Sorts a tensor while placing NaN values at the end along the specified axis.
 
         :param tensor: The input tensor.
-        :param axis: The axis along which to sort.
         :returns: The sorted tensor with NaN values placed at the end.
         """
         # Replace NaNs with a very large value to move them to the end

--- a/src/kamae/tensorflow/layers/string_contains.py
+++ b/src/kamae/tensorflow/layers/string_contains.py
@@ -85,7 +85,7 @@ class StringContainsLayer(BaseLayer):
         is either a single tensor or an iterable of tensors. Returns this result as a
         list of tensors for easier use here.
 
-        :param: inputs: A string tensor or iterable of up to two string tensors.
+        :param inputs: A string tensor or iterable of up to two string tensors.
             In the case two tensors are passed, require that the first tensor is the
             tensor to match a pattern/substring against.
         :returns: A boolean tensor whether the string/string elements are matched.

--- a/src/kamae/tensorflow/layers/string_contains_list.py
+++ b/src/kamae/tensorflow/layers/string_contains_list.py
@@ -75,7 +75,7 @@ class StringContainsListLayer(BaseLayer):
         is a single tensor. Raises an error if multiple tensors are passed
         in as an iterable.
 
-        :param: inputs: Input string tensor.
+        :param inputs: Input string tensor.
         :returns: A boolean tensor indicating whether any of the string constants are
         matched.
         """

--- a/src/kamae/tensorflow/layers/string_isin_list.py
+++ b/src/kamae/tensorflow/layers/string_isin_list.py
@@ -71,7 +71,7 @@ class StringIsInListLayer(BaseLayer):
         is a single tensor. Raises an error if multiple tensors are passed
         in as an iterable.
 
-        :param: inputs: Input string tensor.
+        :param inputs: Input string tensor.
         :returns: A boolean tensor indicating whether any of the string is matched.
         """
         strings = tf.constant(self.string_constant_list)

--- a/src/kamae/tensorflow/layers/string_map.py
+++ b/src/kamae/tensorflow/layers/string_map.py
@@ -81,7 +81,7 @@ class StringMapLayer(BaseLayer):
         is a single tensor. Raises an error if multiple tensors are passed
         in as an iterable.
 
-        :param: inputs: Input string tensor.
+        :param inputs: Input string tensor.
         :returns: A string tensor with the matched strings replaced.
         """
 

--- a/src/kamae/tensorflow/layers/string_replace.py
+++ b/src/kamae/tensorflow/layers/string_replace.py
@@ -100,7 +100,7 @@ class StringReplaceLayer(BaseLayer):
         is either a single tensor or an iterable of tensors. Returns this result as a
         list of tensors for easier use here.
 
-        :param: inputs: A string tensor or iterable of up to three string
+        :param inputs: A string tensor or iterable of up to three string
             tensors.
             In the case multiple tensors are passed, require that the order of inputs is
              [string input, {string match tensor}, {string replace tensor}].
@@ -195,7 +195,7 @@ class StringReplaceLayer(BaseLayer):
     ) -> Union[str, Tensor]:
         """
         Escapes special characters in a string so they are not parsed as regex.
-        :param string: The string or string tensor to escape special characters in.
+        :param string_to_escape: The string or string tensor to escape special characters in.
         :returns: The escaped string or string tensor.
         """
 

--- a/src/kamae/tensorflow/utils/date_utils.py
+++ b/src/kamae/tensorflow/utils/date_utils.py
@@ -62,7 +62,7 @@ def datetime_days_to_month(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Helper function for some datetime functions.
     Gets the number of days to the month of the given datetime tensor.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -99,7 +99,7 @@ def datetime_year(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a year tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -118,7 +118,7 @@ def datetime_month(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a month tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -137,7 +137,7 @@ def datetime_day(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a day tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -156,7 +156,7 @@ def datetime_hour(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into an hour tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -178,7 +178,7 @@ def datetime_minute(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a minute tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -200,7 +200,7 @@ def datetime_second(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a second tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -222,7 +222,7 @@ def datetime_millisecond(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a millisecond tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -242,7 +242,7 @@ def datetime_total_days(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a total days tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -287,7 +287,7 @@ def datetime_total_seconds(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a total seconds tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -317,7 +317,7 @@ def datetime_total_milliseconds(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a total milliseconds tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -347,7 +347,7 @@ def datetime_weekday(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a weekday tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -366,7 +366,7 @@ def datetime_is_weekend(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a weekend tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such
@@ -385,7 +385,7 @@ def datetime_day_of_year(datetime_tensor: tf.Tensor) -> tf.Tensor:
     Utility function to parse a date(time) tensor into a day of year tensor.
     Uses native tf functions only to avoid serialization issues.
 
-    :param: datetime_tensor: date(time) string tensor.
+    :param datetime_tensor: date(time) string tensor.
     Must be in yyyy-MM-dd (HH:mm:ss.SSS) format.
 
     WARNING: Dates are not checked for validity, so if you pass in a date such


### PR DESCRIPTION
- Set the docstring style to Sphinx, this gives us proper tables for func params
- Removed/renamed param docstrings that needed it
- Ensured we don't have any malformed `:param` blocks