### PR TITLE
feat: Allow layer and output names to be equal

### DIFF
--- a/docs/chaining_models.md
+++ b/docs/chaining_models.md
@@ -39,10 +39,7 @@ inputs_with_names = list(zip(model.input_names, model.inputs))
 ### Accessing model outputs
 
 With your Kamae model, you can access the outputs of the model via the `outputs` attribute of the model.
-We add an Identity layer to each output (to preserve the name of the output), but this means that the `name`
-attribute of the output will be `<OUTPUT_NAME>/Identity:0`.
-
-Therefore, you can either split these strings, or zip the `output_names` attribute of your model with the `outputs` attribute, to assign the names to the outputs.
+The output names match the pipeline output column names directly, and can be accessed via the `output_names` attribute of the model.
 
 
 ## Combining your Kamae processing model with a trained Keras model

--- a/src/kamae/graph/pipeline_graph.py
+++ b/src/kamae/graph/pipeline_graph.py
@@ -20,8 +20,6 @@ import networkx as nx
 import tensorflow as tf
 from packaging.version import Version
 
-from kamae.tensorflow.layers import IdentityLayer
-
 keras_version = Version(keras.__version__)
 
 
@@ -109,9 +107,13 @@ class PipelineGraph:
             edges_to_add.extend(
                 [(input_name, layer_name) for input_name in layer_info["inputs"]]
             )
-            # Add edges for all outputs
+            # Add edges for all outputs (skip self-loops where output_name == layer_name)
             edges_to_add.extend(
-                [(layer_name, output_name) for output_name in layer_info["outputs"]]
+                [
+                    (layer_name, output_name)
+                    for output_name in layer_info["outputs"]
+                    if output_name != layer_name
+                ]
             )
 
         graph.add_edges_from(edges_to_add)
@@ -123,8 +125,7 @@ class PipelineGraph:
         """
         Gets the outputs of the model. If output_names is provided, we use this to find
         the outputs for the model. Otherwise, the outputs are those that are not reused
-        and not inputs. We also apply an identity layer to the outputs, so we
-        can rename them with the same name as the output columns of the layer.
+        and not inputs.
 
         :param output_names: Optional list of output names. If provided, the outputs
         are only allowed to be within this list.
@@ -139,12 +140,7 @@ class PipelineGraph:
                 if not v["reused"] and k not in self.inputs
             ]
         return {
-            # Do not wrap with identity if we are just passing through an input.
-            k: IdentityLayer(name=k)(v["output"])
-            if k not in self.inputs
-            else v["output"]
-            for k, v in self.layer_store.items()
-            if k in output_names
+            k: v["output"] for k, v in self.layer_store.items() if k in output_names
         }
 
     def build_keras_inputs(

--- a/src/kamae/sklearn/params/base.py
+++ b/src/kamae/sklearn/params/base.py
@@ -91,8 +91,6 @@ class SingleOutputMixin(LayerNameMixin):
     def output_col(self, value: str) -> None:
         """
         Sets the output column name to the given string value.
-        Throws an error if the value is the same as the layer name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the output_col parameter to.
         :returns: None, output_col is set to the given value.
@@ -100,28 +98,16 @@ class SingleOutputMixin(LayerNameMixin):
         if value is None:
             # Set default output column name
             self._output_col = "output"
-        if hasattr(self, "layer_name") and self.layer_name == value:
-            raise ValueError(
-                f"""Output column name {value} cannot be the same
-                as the layer name {self.layer_name}"""
-            )
         self._output_col = value
 
     @LayerNameMixin.layer_name.setter
     def layer_name(self, value: str) -> None:
         """
         Sets the layer name to the given string value.
-        Throws an error if the value is the same as the output column name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the layer_name parameter to.
         :returns: None, layer_name is set to the given value.
         """
-        if hasattr(self, "output_col") and self.output_col == value:
-            raise ValueError(
-                f"""Layer name {value} cannot be the same
-                as the output column name {self.output_col}"""
-            )
         self._layer_name = value if value is not None else self.__repr__()
 
 
@@ -145,36 +131,20 @@ class MultiOutputMixin(LayerNameMixin):
     def layer_name(self, value: str) -> None:
         """
         Sets the layer name to the given string value.
-        Throws an error if the value is the same as any of the output column names,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the layer_name parameter to.
         :returns: None, layer_name is set to the given value.
         """
-        if hasattr(self, "output_cols") and any(
-            [output_col == value for output_col in self.output_cols]
-        ):
-            raise ValueError(
-                f"""Layer name {value} cannot be the same
-                as any of the output column names {", ".join(self.output_cols)}"""
-            )
         self._layer_name = value if value is not None else self.__repr__()
 
     @output_cols.setter
     def output_cols(self, value: List[str]) -> None:
         """
         Sets the output column names to the given list of strings.
-        Throws an error if any of the values in the list is the same as the layer name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: List of strings to set the output_cols parameter to.
         :returns: None, output_cols is set to the given value.
         """
-        if hasattr(self, "layer_name") and self.layer_name in value:
-            raise ValueError(
-                f"""Output column names {", ".join(value)} cannot contain
-                the layer name {self.layer_name}"""
-            )
         self._output_cols = value
 
 

--- a/src/kamae/spark/params/base.py
+++ b/src/kamae/spark/params/base.py
@@ -206,29 +206,19 @@ class SingleOutputParams(HasLayerName, HasOutputCol, HasOutputDtype):
     def setLayerName(self, value: str) -> "SingleOutputParams":
         """
         Sets the parameter layerName to the given string value.
-        Throws an error if the value is the same as the output column name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the layerName parameter to.
         :returns: Instance of class mixed in.
         """
-        if self.hasParam("outputCol") and self.isDefined("outputCol"):
-            if value == self.getOutputCol():
-                raise ValueError("Layer name and output column name must be different.")
         return self._set(layerName=value)
 
     def setOutputCol(self, value: str) -> "SingleOutputParams":
         """
         Sets the parameter outputCol to the given string value.
-        Throws an error if the value is the same as the layer name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the outputCol parameter to.
         :returns: Instance of class mixed in.
         """
-        if self.hasParam("layerName") and self.isDefined("layerName"):
-            if value == self.getLayerName():
-                raise ValueError("Layer name and output column name must be different.")
         return self._set(outputCol=value)
 
 
@@ -240,33 +230,19 @@ class MultiOutputParams(HasLayerName, HasOutputCols, HasOutputDtype):
     def setLayerName(self, value: str) -> "MultiOutputParams":
         """
         Sets the parameter layerName to the given string value.
-        Throws an error if the value is the same as one of the output column names,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: String to set the layerName parameter to.
         :returns: Instance of class mixed in.
         """
-        if self.hasParam("outputCol") and self.isDefined("outputCols"):
-            if value in self.getOutputCols():
-                raise ValueError(
-                    "Layer name and output column names must be different."
-                )
         return self._set(layerName=value)
 
     def setOutputCols(self, value: List[str]) -> "MultiOutputParams":
         """
         Sets the parameter outputCols to the given list of strings.
-        Throws an error if one of the output column names is the same as the layer name,
-        as this causes issues when constructing the pipeline graph.
 
         :param value: List of strings to set the outputCols parameter to.
         :returns: Instance of class mixed in.
         """
-        if self.hasParam("layerName") and self.isDefined("layerName"):
-            if self.getLayerName() in value:
-                raise ValueError(
-                    "Layer name and output column names must be different."
-                )
         return self._set(outputCols=value)
 
 

--- a/tests/kamae/graph/test_pipeline_graph.py
+++ b/tests/kamae/graph/test_pipeline_graph.py
@@ -163,6 +163,19 @@ class TestPipelineGraph:
                     ("layer4", "layer4_output1"),
                 ],
             ),
+            (
+                {
+                    "layer1": {
+                        "name": "layer1",
+                        "layer": None,
+                        "inputs": ["input1"],
+                        "outputs": ["layer1"],
+                    },
+                },
+                [
+                    ("input1", "layer1"),
+                ],
+            ),
         ],
     )
     def test_add_stage_edges(self, stage_dict, expected_edges):


### PR DESCRIPTION
- Previously we did not allow this and added an identity layer to all model outputs