### PR TITLE
fix: standard scaling do not replace 0 variance with epsilon

### DIFF
--- a/src/kamae/tensorflow/layers/conditional_standard_scale.py
+++ b/src/kamae/tensorflow/layers/conditional_standard_scale.py
@@ -105,15 +105,7 @@ class ConditionalStandardScaleLayer(NormalizeLayer):
         variance = self._cast(self.variance, inputs.dtype.name)
         normalized_outputs = tf.math.divide_no_nan(
             tf.math.subtract(inputs, mean),
-            tf.math.maximum(
-                tf.sqrt(variance), tf.constant(self.epsilon, dtype=inputs.dtype)
-            ),
-        )
-        # output is 0 if variance is 0
-        normalized_outputs = tf.where(
-            tf.equal(variance, 0),
-            tf.zeros_like(normalized_outputs),
-            normalized_outputs,
+            tf.sqrt(variance),
         )
         if self.skip_zeros:
             eps = tf.constant(self.epsilon, dtype=inputs.dtype)

--- a/src/kamae/tensorflow/layers/standard_scale.py
+++ b/src/kamae/tensorflow/layers/standard_scale.py
@@ -99,7 +99,7 @@ class StandardScaleLayer(NormalizeLayer):
         variance = self._cast(self.variance, inputs.dtype.name)
         normalized_outputs = tf.math.divide_no_nan(
             tf.math.subtract(inputs, mean),
-            tf.math.maximum(tf.sqrt(variance), tf.constant(1e-8, dtype=inputs.dtype)),
+            tf.sqrt(variance),
         )
         if self.mask_value is not None:
             mask = tf.equal(inputs, self.mask_value)

--- a/tests/kamae/spark/transformers/test_standard_scale.py
+++ b/tests/kamae/spark/transformers/test_standard_scale.py
@@ -449,6 +449,40 @@ class TestStandardScale:
             err_msg="Spark and Tensorflow transform outputs are not equal",
         )
 
+    def test_zero_variance_spark_tf_parity(self, spark_session):
+        """Zero-variance features produce 0.0 in both Spark and TF layers."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0], [5.0, 5.0, 5.0]])
+        mean = [5.0, 5.0, 5.0]
+        stddev = [0.0, 0.0, 0.0]
+
+        transformer = StandardScaleTransformer(
+            inputCol="input",
+            outputCol="output",
+            mean=mean,
+            stddev=stddev,
+        )
+
+        spark_df = spark_session.createDataFrame(
+            [(v,) for v in input_tensor.numpy().tolist()], ["input"]
+        )
+        spark_values = (
+            transformer.transform(spark_df)
+            .select("output")
+            .rdd.map(lambda r: r[0])
+            .collect()
+        )
+        tensorflow_values = transformer.get_tf_layer()(input_tensor).numpy().tolist()
+
+        expected = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        np.testing.assert_almost_equal(spark_values, expected, decimal=6)
+        np.testing.assert_almost_equal(tensorflow_values, expected, decimal=6)
+        np.testing.assert_almost_equal(
+            spark_values,
+            tensorflow_values,
+            decimal=6,
+            err_msg="Spark and TF outputs differ for zero-variance features",
+        )
+
     @pytest.mark.parametrize(
         "input_col, output_col",
         [

--- a/tests/kamae/tensorflow/layers/test_conditional_standard_scale.py
+++ b/tests/kamae/tensorflow/layers/test_conditional_standard_scale.py
@@ -172,6 +172,31 @@ class TestConditionalStandardScale:
         else:
             tf.debugging.assert_near(expected_output, output_tensor)
 
+    def test_zero_variance_produces_zero_output(self):
+        """Zero-variance features should produce 0.0 even when input != mean."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0]])
+        layer = ConditionalStandardScaleLayer(
+            name="zero_var",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
+    def test_zero_variance_with_skip_zeros(self):
+        """Zero-variance + skip_zeros: both zero-input and non-zero-input produce 0.0."""
+        input_tensor = tf.constant([[0.0, 3.0, 7.0]])
+        layer = ConditionalStandardScaleLayer(
+            name="zero_var_skip",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+            skip_zeros=True,
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
     @pytest.mark.parametrize(
         "inputs, input_name, input_dtype, output_dtype",
         [

--- a/tests/kamae/tensorflow/layers/test_standard_scale.py
+++ b/tests/kamae/tensorflow/layers/test_standard_scale.py
@@ -171,6 +171,18 @@ class TestStandardScale:
         ), "Output tensor shape is not the same as expected tensor shape"
         tf.debugging.assert_near(expected_output, output_tensor, atol=1e-6)
 
+    def test_zero_variance_produces_zero_output(self):
+        """Zero-variance features should produce 0.0, matching Spark behavior."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0]])
+        layer = StandardScaleLayer(
+            name="zero_var",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
     @pytest.mark.parametrize(
         "inputs, input_name, input_dtype, output_dtype",
         [


### PR DESCRIPTION
### Description
On tensorflow side, in standard scaler zero variance was replaced by tiny float. This was not matching spark behaviour where 0 is output in such case. Aligned tensorflow layers to spark. Added tests for zero variance condition.

Conditional standard scaler was actually working but I simplified the code.

