### PR TITLE
fix: standard scaling - do not replace 0 variance with epsilon

### DIFF
--- a/src/kamae/keras/core/layers/conditional_standard_scale.py
+++ b/src/kamae/keras/core/layers/conditional_standard_scale.py
@@ -118,17 +118,7 @@ class ConditionalStandardScaleLayer(NormalizeLayer):
 
         # Compute (input - mean) / sqrt(variance) using safe division
         numerator = ops.subtract(inputs, mean)
-        denominator = ops.maximum(
-            ops.sqrt(variance), ops.convert_to_tensor(self.epsilon, dtype=inputs.dtype)
-        )
-        normalized_outputs = divide_no_nan(numerator, denominator)
-
-        # Output is 0 if variance is 0
-        normalized_outputs = ops.where(
-            ops.equal(variance, 0),
-            ops.zeros_like(normalized_outputs),
-            normalized_outputs,
-        )
+        normalized_outputs = divide_no_nan(numerator, ops.sqrt(variance))
 
         if self.skip_zeros:
             eps = ops.convert_to_tensor(self.epsilon, dtype=inputs.dtype)

--- a/src/kamae/keras/core/layers/standard_scale.py
+++ b/src/kamae/keras/core/layers/standard_scale.py
@@ -110,10 +110,7 @@ class StandardScaleLayer(NormalizeLayer):
 
         # Compute (input - mean) / sqrt(variance) using safe division
         numerator = ops.subtract(inputs, mean)
-        denominator = ops.maximum(
-            ops.sqrt(variance), ops.convert_to_tensor(1e-8, dtype=inputs.dtype)
-        )
-        normalized_outputs = divide_no_nan(numerator, denominator)
+        normalized_outputs = divide_no_nan(numerator, ops.sqrt(variance))
 
         if self.mask_value is not None:
             mask = ops.equal(inputs, self.mask_value)

--- a/tests/kamae/keras/core/layers/test_conditional_standard_scale.py
+++ b/tests/kamae/keras/core/layers/test_conditional_standard_scale.py
@@ -172,6 +172,31 @@ class TestConditionalStandardScale:
         else:
             tf.debugging.assert_near(expected_output, output_tensor)
 
+    def test_zero_variance_produces_zero_output(self):
+        """Zero-variance features should produce 0.0 even when input != mean."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0]])
+        layer = ConditionalStandardScaleLayer(
+            name="zero_var",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
+    def test_zero_variance_with_skip_zeros(self):
+        """Zero-variance + skip_zeros: both zero-input and non-zero-input produce 0.0."""
+        input_tensor = tf.constant([[0.0, 3.0, 7.0]])
+        layer = ConditionalStandardScaleLayer(
+            name="zero_var_skip",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+            skip_zeros=True,
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
     @pytest.mark.parametrize(
         "inputs, input_name, input_dtype, output_dtype",
         [

--- a/tests/kamae/keras/core/layers/test_standard_scale.py
+++ b/tests/kamae/keras/core/layers/test_standard_scale.py
@@ -171,6 +171,18 @@ class TestStandardScale:
         ), "Output tensor shape is not the same as expected tensor shape"
         tf.debugging.assert_near(expected_output, output_tensor, atol=1e-6)
 
+    def test_zero_variance_produces_zero_output(self):
+        """Zero-variance features should produce 0.0, matching Spark behavior."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0]])
+        layer = StandardScaleLayer(
+            name="zero_var",
+            mean=[5.0, 5.0, 5.0],
+            variance=[0.0, 0.0, 0.0],
+        )
+        output_tensor = layer(input_tensor)
+        expected = tf.constant([[0.0, 0.0, 0.0]])
+        tf.debugging.assert_near(output_tensor, expected)
+
     @pytest.mark.parametrize(
         "inputs, input_name, input_dtype, output_dtype",
         [

--- a/tests/kamae/spark/transformers/test_standard_scale.py
+++ b/tests/kamae/spark/transformers/test_standard_scale.py
@@ -449,6 +449,40 @@ class TestStandardScale:
             err_msg="Spark and Tensorflow transform outputs are not equal",
         )
 
+    def test_zero_variance_spark_keras_parity(self, spark_session):
+        """Zero-variance features produce 0.0 in both Spark and Keras layers."""
+        input_tensor = tf.constant([[3.0, 5.0, 7.0], [5.0, 5.0, 5.0]])
+        mean = [5.0, 5.0, 5.0]
+        stddev = [0.0, 0.0, 0.0]
+
+        transformer = StandardScaleTransformer(
+            inputCol="input",
+            outputCol="output",
+            mean=mean,
+            stddev=stddev,
+        )
+
+        spark_df = spark_session.createDataFrame(
+            [(v,) for v in input_tensor.numpy().tolist()], ["input"]
+        )
+        spark_values = (
+            transformer.transform(spark_df)
+            .select("output")
+            .rdd.map(lambda r: r[0])
+            .collect()
+        )
+        keras_values = transformer.get_keras_layer()(input_tensor).numpy().tolist()
+
+        expected = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        np.testing.assert_almost_equal(spark_values, expected, decimal=6)
+        np.testing.assert_almost_equal(keras_values, expected, decimal=6)
+        np.testing.assert_almost_equal(
+            spark_values,
+            keras_values,
+            decimal=6,
+            err_msg="Spark and Keras outputs differ for zero-variance features",
+        )
+
     @pytest.mark.parametrize(
         "input_col, output_col",
         [


### PR DESCRIPTION
### Description
Same as #53 but for keras.